### PR TITLE
fix: Correctly handle multiple $ANIME results

### DIFF
--- a/eztrackma
+++ b/eztrackma
@@ -21,7 +21,7 @@ case $PROMPT in
     CHOICE=$(printf "filter watching\nls"|trackma -a 1|grep -Eo "$REGEX"|$FZF -i --prompt="Choose an anime to watch: ")
     INDEX=$(printf "%s" "$CHOICE"|cut -d" " -f1)
 		ANIME="$(trackma -a 1 info "$INDEX"|head -n 1)"
-		EPNUM="$(trackma -a 1 search "$ANIME"|sed -En "s/.*\.[[:space:]]+([0-9]*) \/.*/\1/p")"
+		EPNUM="$(trackma -a 1 search "$ANIME"|sed -En "s/.*\.[[:space:]]+([0-9]*) \/.*/\1/p"|head -n 1)"
 		animdl stream "$ANIME" -r $((EPNUM+1))
 		# ani-cli -a $((EPNUM+1)) "$ANIME"
 		while true; do


### PR DESCRIPTION
It just selects the first (most accurate result).
The bug happened if, for instance, i have `Mob Psycho 100 II` and `Mob Psycho 100 III` in my `watching` list and i select `Mob Psycho 100 II` in the `watch` menu, because `trackma -a 1 search "$ANIME"` finds both, which makes the `$EPNUM` variable something like `0 0` and breaks `animdl stream "$ANIME" -r $((EPNUM+1))`.